### PR TITLE
[fix] Make public api self contained

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdarg.h>
+
 #define LOG_VERSION "0.1.0"
 
 typedef struct {


### PR DESCRIPTION
When log.h is included by other applications and they don't include stdarg.h before log.h, programs will not compile. In order to make the header self-contained, I include stdarg.h to avoid these cases.